### PR TITLE
Fix Message timestamp bug

### DIFF
--- a/src/main/java/model/Message.java
+++ b/src/main/java/model/Message.java
@@ -8,7 +8,7 @@ public class Message {
     public Message(String sender, String content, long timestamp) {
         this.sender = sender;
         this.content = content;
-        this.timestamp = System.currentTimeMillis();
+        this.timestamp = timestamp;
     }
 
     public String getSender() {


### PR DESCRIPTION
## Summary
- fix `Message` constructor to use provided timestamp parameter

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_683f40d037588325b96286fc291723c6