### PR TITLE
Replace servlet chat with WebSocket

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     compileOnly('jakarta.servlet:jakarta.servlet-api:6.1.0')
     compileOnly('jakarta.transaction:jakarta.transaction-api:2.0.1')
     compileOnly('jakarta.websocket:jakarta.websocket-api:2.2.0')
+    compileOnly('jakarta.websocket:jakarta.websocket-client-api:2.2.0')
     compileOnly('jakarta.xml.ws:jakarta.xml.ws-api:4.0.2')
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:${junitVersion}")

--- a/src/main/java/controller/ChatWebSocket.java
+++ b/src/main/java/controller/ChatWebSocket.java
@@ -1,0 +1,74 @@
+package controller;
+
+import jakarta.websocket.OnClose;
+import jakarta.websocket.OnMessage;
+import jakarta.websocket.OnOpen;
+import jakarta.websocket.Session;
+import jakarta.websocket.server.ServerEndpoint;
+import model.Message;
+
+import jakarta.json.bind.Jsonb;
+import jakarta.json.bind.JsonbBuilder;
+import java.io.IOException;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
+
+/**
+ * WebSocket endpoint for broadcasting chat messages between clients.
+ */
+@ServerEndpoint("/chat")
+public class ChatWebSocket {
+
+    /**
+     * Active WebSocket sessions connected to this endpoint.
+     */
+    private static final Set<Session> sessions = new CopyOnWriteArraySet<>();
+
+    private static final Jsonb jsonb = JsonbBuilder.create();
+
+    /**
+     * Adds a newly opened session to the active session set.
+     *
+     * @param session the newly opened WebSocket session
+     */
+    @OnOpen
+    public void onOpen(Session session) {
+        sessions.add(session);
+    }
+
+    /**
+     * Receives a message from a client and broadcasts it to all connected
+     * sessions. Incoming JSON is deserialized to a {@link Message} and the
+     * server adds a timestamp before rebroadcasting.
+     *
+     * @param messageJson the incoming message in JSON format
+     * @param session     the WebSocket session that sent the message
+     */
+    @OnMessage
+    public void onMessage(String messageJson, Session session) {
+        try {
+            Message message = jsonb.fromJson(messageJson, Message.class);
+            // Ensure a timestamp is set for the broadcasted message
+            Message broadcast = new Message(message.getSender(), message.getContent(), System.currentTimeMillis());
+            String json = jsonb.toJson(broadcast);
+            for (Session s : sessions) {
+                if (s.isOpen()) {
+                    s.getBasicRemote().sendText(json);
+                }
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Removes the session from the active session set once the connection is
+     * closed.
+     *
+     * @param session the WebSocket session that was closed
+     */
+    @OnClose
+    public void onClose(Session session) {
+        sessions.remove(session);
+    }
+}


### PR DESCRIPTION
## Summary
- add `ChatWebSocket` endpoint to broadcast chat messages
- add WebSocket client API dependency

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_684f2d1c1f8883258776f4c08f2589a8